### PR TITLE
Fix auth source validation in Activate method

### DIFF
--- a/component/mongodbc/mongodbc.go
+++ b/component/mongodbc/mongodbc.go
@@ -123,7 +123,7 @@ func (m *mongoDbComponent) Activate(ctx sctx.ServiceContext) error {
 		})
 	}
 	// validate auth source, return err
-	if opts.Auth.AuthSource == "" {
+	if m.authSource == "" {
 		return errors.New("auth source is empty")
 	}
 


### PR DESCRIPTION
Correct the validation logic for the authentication source in the Activate method to ensure it checks the appropriate variable.